### PR TITLE
CONFIGURE: fix building with automake-1.13

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 AC_PREREQ(2.52)
 
 AC_INIT(src/udevil.c)
-AM_CONFIG_HEADER(config.h)
+AC_CONFIG_HEADERS(config.h)
 AC_CONFIG_SRCDIR(src)
 AM_INIT_AUTOMAKE(udevil, 0.4.1+)
 


### PR DESCRIPTION
AM_CONFIG_HEADER -> AC_CONFIG_HEADERS

the former is fatal since automake-1.13, but it also works with previous automake since it was in deprecation phase
