### PR TITLE
Update fmask to 0133 in "allowed_options" to fix vfat ntfs msdos umsdos ...

### DIFF
--- a/etc/udevil.conf
+++ b/etc/udevil.conf
@@ -241,7 +241,7 @@ default_options_ramfs     = nosuid, noexec, nodev, noatime, uid=$UID, gid=$GID
 # and GID.
 # If you want to forbid remounts, remove 'remount' from here.
 # WARNING:  OPTIONS HERE CAN CAUSE SERIOUS SECURITY PROBLEMS - CHOOSE CAREFULLY
-allowed_options           = nosuid, noexec, nodev, noatime, fmask=0022, dmask=0022, uid=$UID, gid=$GID, ro, rw, sync, flush, iocharset=*, utf8, remount
+allowed_options           = nosuid, noexec, nodev, noatime, fmask=0133, dmask=0022, uid=$UID, gid=$GID, ro, rw, sync, flush, iocharset=*, utf8, remount
 allowed_options_nfs       = nosuid, noexec, nodev, noatime, ro, rw, sync, remount, port=*, rsize=*, wsize=*, hard, proto=*, timeo=*, retrans=*
 allowed_options_cifs      = nosuid, noexec, nodev, ro, rw, remount, port=*, user=*, username=*, pass=*, password=*, guest, domain=*, uid=$UID, gid=$GID, credentials=*
 allowed_options_smbfs     = nosuid, noexec, nodev, ro, rw, remount, port=*, user=*, username=*, pass=*, password=*, guest, domain=*, uid=$UID, gid=$GID, credentials=*


### PR DESCRIPTION
...mounting

This commit: https://github.com/IgnorantGuru/udevil/commit/12a3cf4a0c4aacb9d36007038f4f2d974fc248d4 changed fmask from 0022 to 0133 but didn't update the allowed_options variable.
