### PR TITLE
New: Added ability to run under a user's systemd session

### DIFF
--- a/etc/systemd/devmon@.service
+++ b/etc/systemd/devmon@.service
@@ -11,3 +11,4 @@ ExecStart=/usr/bin/devmon $ARGS
 
 [Install]
 WantedBy=multi-user.target
+WantedBy=default.target


### PR DESCRIPTION
I'd like to run `devmon` as my user rather than root so that devices are mounted in a way that is writeable by my.

When I tried `systemctl --user enable devmon` I was informed that no target existed for a user, so I', submitting this PR to add it
