### PR TITLE
Add include for stat()

### DIFF
--- a/src/device-info.c
+++ b/src/device-info.c
@@ -4,6 +4,7 @@
 ************************************************************************** */
 
 #include "device-info.h"
+#include <sys/stat.h>
 
 static char *
 _dupv8 (const char *s)


### PR DESCRIPTION
We need the stat.h file for the prototypes for stat() and S_ISBLK calls
