### PR TITLE
Fix "implicit declaration of function stat"

### DIFF
--- a/src/device-info.h
+++ b/src/device-info.h
@@ -14,6 +14,7 @@
 #include <libudev.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <sys/stat.h>
 
 // intltool
 #include <glib/gi18n.h>


### PR DESCRIPTION
This only appears on some system, but the provided include
seems to fix it.

See https://galileo.mailstation.de/jenkins/job/medvid/62/console
for the build failure log.
