### PR TITLE
notify-send as fallback

### DIFF
--- a/src/devmon
+++ b/src/devmon
@@ -344,6 +344,7 @@ udisks2=`which udisksctl 2>/dev/null`
 pmount=`which pmount 2>/dev/null`
 zenity=`which zenity 2>/dev/null`
 spacefm=`which spacefm 2>/dev/null`
+notify_send=`which notify-send 2>/dev/null`
 
 if [ "$udevil" != "" ] && [ -x "$udevil" ]; then
 	info_cmd="$udevil"
@@ -550,9 +551,11 @@ mountdev()   # $1=device  [$2=label]  [$3=devtype or fstype]
 					if (( nogui != 1 )); then
 						if [ "$spacefm" != "" ]; then
 							( sleep 3 && $spacefm -g --title "devmon error" --window-icon error --label "udisks functions are not authorized through policykit,\nso devmon cannot automount drives.\nPlease install udevil or see devmon's consolekit installation instructions:\n\nhttp://igurublog.wordpress.com/downloads/script-devmon/#install\n\n(To silence this pop-up add --no-gui to devmon's command line.)" --button "Open Website" xdg-open "http://igurublog.wordpress.com/downloads/script-devmon/#install" --button ok &> /dev/null ) &							
-						else
+						elif [ "$zenity" != "" ]; then
 							( sleep 3 && WINDOWID="" $zenity --error --no-wrap --title="devmon error" \
 							  --text="udisks functions are not authorized through policykit,\nso devmon cannot automount drives.\nPlease install udevil or see devmon's consolekit installation instructions:\n\nhttp://igurublog.wordpress.com/downloads/script-devmon/#install\n\n(To silence this pop-up add --no-gui to devmon's command line.)" &> /dev/null ) &
+						else
+							( sleep 3 && $notify_send --icon=dialog-error "devmon error" "udisks functions are not authorized through policykit,\nso devmon cannot automount drives.\nPlease install udevil or see devmon's consolekit installation instructions:\n\nhttp://igurublog.wordpress.com/downloads/script-devmon/#install\n\n(To silence this pop-up add --no-gui to devmon's command line.)" &> /dev/null ) &
 						fi
 					fi
 					echo "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@" 1>&2
@@ -726,9 +729,12 @@ mountdrive()   # $1=device $2=label  [$3=devtype or fstype]
 				"The following device has been mounted:\n\n$(df -hT "$dv" | grep "$dv" | \
 				awk '{print "Device:\\t"$1"\x0AType:\\t"$2"\nSize:\\t\\t"$3"\nUsed:\\t"$4"\n""Avail:\\t"$5"\nUse%:\\t"$6"\nMount:\\t"$7,$8,$9,$10}')\nLabel:\\t$lb" \
 				--button open spacefm "$point" --button ok &>/dev/null &
-			else
+			elif [ "$zenity" != "" ]; then
 				WINDOWID="" $zenity --info --text="The following device has been mounted:\n\n$(df -hT "$dv" \
 			   | grep "$dv" | awk '{print "Device:\\t"$1"\x0AType:\\t"$2"\nSize:\\t\\t"$3"\nUsed:\\t"$4"\n""Avail:\\t"$5"\nUse%:\\t"$6"\nMount:\\t"$7,$8,$9,$10}')\nLabel:\\t$lb" --title="devmon mount" &
+			else
+				$notify_send --icon=media-removable "devmon mount" "The following device has been mounted:\n\n$(df -hT "$dv" \
+				 | grep "$dv" | awk '{print "Device:\\t"$1"\x0AType:\\t"$2"\nSize:\\t\\t"$3"\nUsed:\\t"$4"\n""Avail:\\t"$5"\nUse%:\\t"$6"\nMount:\\t"$7,$8,$9,$10}')\nLabel:\\t$lb" &
 			fi
 		fi
 		df -hT "$dv"
@@ -888,8 +894,10 @@ if (( mountmode != 0 )); then
 		if (( nogui != 1 )); then
 			if [ "$spacefm" != "" ]; then
 				spacefm -g --title "$msgtitle" --label "$msg" --button close &> /dev/null &
-			else
+			elif [ "$zenity" != "" ]; then
 				WINDOWID="" zenity --info --title="$msgtitle" --text="$msg" &> /dev/null &
+			else
+				"$notify_send" --icon=media-eject "$msgtitle" "$msg" &> /dev/null &
 			fi
 			zpid=$!
 		fi
@@ -909,8 +917,10 @@ if (( mountmode != 0 )); then
 					if [ "$spacefm" != "" ]; then
 						spacefm -g --title "$msgtitle" --window-icon error \
 						           --label "$msg" --button close &> /dev/null &
-					else
+					elif [ "$zenity" != "" ]; then
 						WINDOWID="" zenity --error --title="$msgtitle" --text="$msg" &> /dev/null &
+					else
+						"$notify_send" --icon=dialog-error "$msgtitle" "$msg" &> /dev/null &
 					fi
 				fi	
 			done
@@ -950,9 +960,11 @@ if (( mountmode != 0 )); then
 							spacefm -g --title "devmon unmount optical" \
 							           --window-icon error \
 							           --label "$msg" --button close &> /dev/null &
-						else
+						elif [ "$zenity" != "" ]; then
 							WINDOWID="" zenity --error --title="devmon unmount optical" \
 						                   --text="$msg" &> /dev/null &
+						else
+							"$notify_send" --icon=dialog_error "devmon unmount optical" "$msg"
 						fi
 					fi	
 				fi

--- a/src/devmon
+++ b/src/devmon
@@ -1146,7 +1146,7 @@ err=$?
 trap trapexit EXIT SIGINT SIGTERM SIGQUIT
 trap "echo devmon: ignored HUP" SIGHUP
 
-if [ $err != "0" ] || [ ! ps -p $COPROC_PID &>/dev/null ]; then
+if [ $err != "0" ] || ! ps -p $COPROC_PID &>/dev/null; then
 	echo "devmon: unable to start $info_cmd --monitor" 1>&2
 	exit 2
 fi

--- a/src/devmon
+++ b/src/devmon
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Script Name: devmon    http://igurublog.wordpress.com/downloads/script-devmon/ 
+# Script Name: devmon    http://igurublog.wordpress.com/downloads/script-devmon/
 # Requires:    udevil bash>=4        Recommended: eject spacefm|zenity
 # Optional:    udisks v1 may be substituted for udevil
 #              If udevil is not set suid, udisks v1/v2 or pmount is required
@@ -78,7 +78,7 @@ test2()
 	if [ "${2:0:1}" = "-" ] || [ "$2" = "" ]; then
 		echo "devmon: Option $1 requires an argument" 1>&2
 		exit 1
-	fi	
+	fi
 }
 
 test3()
@@ -87,7 +87,7 @@ test3()
 	   [ "${3:0:1}" = "-" ] || [ "$3" = "" ]; then
 		echo "devmon: Option $1 requires two arguments" 1>&2
 		exit 1
-	fi	
+	fi
 }
 
 unknown()
@@ -247,7 +247,7 @@ while [ "$1" != "" ]; do
 				igdev[$igdevx]="$2"
 				(( igdevx++ ))
 				shift
-				;;				
+				;;
 			--ignore-label )
 				test2 "$1" "$2"
 				iglab[$iglabx]="$2"
@@ -381,7 +381,7 @@ if [ "$mount_cmd" = "" ]; then
 fi
 
 
-driveinfo()    #$1=dev    #Optional $2=quiet 
+driveinfo()    #$1=dev    #Optional $2=quiet
 {
 	unset systeminternal usage ismounted presentationnopolicy hasmedia \
 			opticaldisc numaudiotracks type partition media blank label
@@ -519,9 +519,9 @@ mountdev()   # $1=device  [$2=label]  [$3=devtype or fstype]
 		mntmsg="devmon: $mount_cmd --mount $1 --mount-options \"$mopts\" $fst $mountfstype  $lblcmt"
 	fi
 	if [ "$3" != "nofs" ]; then
-		echo "$mntmsg" 
+		echo "$mntmsg"
 	fi
-	
+
 	# mount
 	if [ "$mount_cmd" = "$udisks2" ]; then
 		umsg=`$mount_cmd mount -b $1 -o "$mopts" $fst $mountfstype 2>&1`
@@ -539,7 +539,7 @@ mountdev()   # $1=device  [$2=label]  [$3=devtype or fstype]
 		point=" "
 	fi
 	if [ "$mounterr" != "0" ] || [ "$point" = "" ]; then
-		# if $3=nofs then there was no apparent filesystem but we tried to mount it 
+		# if $3=nofs then there was no apparent filesystem but we tried to mount it
 		# anyway in case it didn't report the filesystem accurately, so ignore the
 		# error
 		if [ "$3" != "nofs" ]; then
@@ -554,9 +554,9 @@ mountdev()   # $1=device  [$2=label]  [$3=devtype or fstype]
 	udisks functions are not authorized through policykit,
 	so devmon cannot automount drives.
 	Please install udevil or see devmon's consolekit installation instructions:
-	
+
 	http://igurublog.wordpress.com/downloads/script-devmon/#install
-	
+
 	(To silence this pop-up add --no-gui to devmon's command line.)
 						MSG
 						if [ "$spacefm" != "" ]; then
@@ -576,7 +576,7 @@ mountdev()   # $1=device  [$2=label]  [$3=devtype or fstype]
 					echo "Please see devmon's consolekit installation instructions:" 1>&2
 					echo "http://igurublog.wordpress.com/downloads/script-devmon/#install" 1>&2
 					echo "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@" 1>&2
-					echo "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@" 1>&2	
+					echo "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@" 1>&2
 					polkiterrgiven=1
 				fi
 			fi
@@ -587,13 +587,13 @@ mountdev()   # $1=device  [$2=label]  [$3=devtype or fstype]
 		# no filesystem reported but successful mount
 		echo "$mntmsg"
 	fi
-	
+
 	# set devtag for recognizing mounted by devmon
 	devpath="$1"
 	devtag="${devpath#/dev/}"
 	devtag="${devtag//-/_}"
 	eval devmounted${devtag}=1
-	
+
 	echo "$umsg"
 	if [ "$point" = " " ]; then
 		# pmount doesn't output the mount point - get it now
@@ -617,13 +617,13 @@ unmountdev()   # $1=device
 	fi
 	umounterr="$?"
 	if [ "$mount_cmd" = "$udisks1" ] && [ "$uerrmsg" != "" ]; then
-		# bug: udisks v1 returns $?==0 when unmount fails	
+		# bug: udisks v1 returns $?==0 when unmount fails
 		umounterr=1
 	fi
 	if [ "$uerrmsg" != "" ]; then
 		echo "$uerrmsg"
 	fi
-	if [ $umounterr -ne 0 ]; then 
+	if [ $umounterr -ne 0 ]; then
 		uerr=3
 		return 3
 	fi
@@ -810,7 +810,7 @@ mountalldrives()
 			fi
 		fi
 	done
-	IFS="$IFSOLD"	
+	IFS="$IFSOLD"
 }
 
 trapexit()
@@ -934,7 +934,7 @@ if (( mountmode != 0 )); then
 					else
 						"$notify_send" --icon=dialog-error "$msgtitle" "$msg" &> /dev/null &
 					fi
-				fi	
+				fi
 			done
 			echo "devmon: sync"
 			sync
@@ -980,7 +980,7 @@ if (( mountmode != 0 )); then
 							"$notify_send" --icon=dialog-error "$msgtitle" "$msg"
 						fi
 						unset msgtitle msg
-					fi	
+					fi
 				fi
 			fi
 			(( x++ ))
@@ -1077,7 +1077,7 @@ if (( mountmode != 0 )); then
 			(( x++ ))
 		done
 	fi
-	
+
 	# Mount DEVICE
 	if (( mntx > 0 )); then
 		x=0
@@ -1097,7 +1097,7 @@ if (( mountmode != 0 )); then
 				mountdev $d "$label" "$type"
 			fi
 			(( x++ ))
-		done	
+		done
 	fi
 
 	# Mount All Unmounted

--- a/src/devmon
+++ b/src/devmon
@@ -737,7 +737,7 @@ mountdrive()   # $1=device $2=label  [$3=devtype or fstype]
 		if (( nogui != 1 )); then
 			msgtitle="devmon mount"
 			msg="The following device has been mounted:\n\n$(df -hT "$dv" | \
-				awk '$1 == "'$dv'" {print "Device:\\t"$1"\x0AType:\\t"$2"\nSize:\\t\\t"$3"\nUsed:\\t"$4"\n""Avail:\\t"$5"\nUse%:\\t"$6"\nMount:\\t"$7,$8,$9,$10}')\nLabel:\\t$lb"
+				awk '$1 == "'$dv'" {print "Device:\t"$1"\x0AType:\t"$2"\nSize:\t"$3"\nUsed:\t"$4"\n""Avail:\t"$5"\nUse%:\t"$6"\nMount:\t"$7,$8,$9,$10}')\nLabel:\t$lb"
 			if [ "$spacefm" != "" ]; then
 				$spacefm -g --title "$msgtitle" --window-icon drive-removable-media --label \
 				"$msg" \

--- a/src/devmon
+++ b/src/devmon
@@ -736,8 +736,12 @@ mountdrive()   # $1=device $2=label  [$3=devtype or fstype]
 		echo "devmon: [info on mount] $dv"
 		if (( nogui != 1 )); then
 			msgtitle="devmon mount"
-			msg="The following device has been mounted:\n\n$(df -hT "$dv" | \
-				awk '$1 == "'$dv'" {print "Device:\t"$1"\x0AType:\t"$2"\nSize:\t"$3"\nUsed:\t"$4"\n""Avail:\t"$5"\nUse%:\t"$6"\nMount:\t"$7,$8,$9,$10}')\nLabel:\t$lb"
+			msg="$(df -hT "$dv" | awk '
+				BEGIN { l = 7; printf "The following device has been mounted:\n\n" }
+				NR == 1 { split($0, h); h[1] = "Device"; h[7] = "Mount"; delete h[8] }
+				NR == 2 { for (i = 1; i <= NF; i++) printf "%-*s\t%s\n", l, h[i]":", $i }
+				END { printf "%-*s\t%s", l, "Label:", "'$lb'" }
+			')"
 			if [ "$spacefm" != "" ]; then
 				$spacefm -g --title "$msgtitle" --window-icon drive-removable-media --label \
 				"$msg" \

--- a/src/devmon
+++ b/src/devmon
@@ -549,14 +549,25 @@ mountdev()   # $1=device  [$2=label]  [$3=devtype or fstype]
 				if (( mountmode == 0 )) && (( polkiterrgiven != 1 )) && \
 				           [ "$(echo "$umsg" | grep 'Not *Authorized')" != "" ]; then
 					if (( nogui != 1 )); then
+						msgtitle="devmon error"
+						read -rd'\0' msg <<-MSG
+	udisks functions are not authorized through policykit,
+	so devmon cannot automount drives.
+	Please install udevil or see devmon's consolekit installation instructions:
+	
+	http://igurublog.wordpress.com/downloads/script-devmon/#install
+	
+	(To silence this pop-up add --no-gui to devmon's command line.)
+						MSG
 						if [ "$spacefm" != "" ]; then
-							( sleep 3 && $spacefm -g --title "devmon error" --window-icon error --label "udisks functions are not authorized through policykit,\nso devmon cannot automount drives.\nPlease install udevil or see devmon's consolekit installation instructions:\n\nhttp://igurublog.wordpress.com/downloads/script-devmon/#install\n\n(To silence this pop-up add --no-gui to devmon's command line.)" --button "Open Website" xdg-open "http://igurublog.wordpress.com/downloads/script-devmon/#install" --button ok &> /dev/null ) &							
+							( sleep 3 && $spacefm -g --title "$msgtitle" --window-icon error --label "$msg" --button "Open Website" xdg-open "http://igurublog.wordpress.com/downloads/script-devmon/#install" --button ok &> /dev/null ) &
 						elif [ "$zenity" != "" ]; then
-							( sleep 3 && WINDOWID="" $zenity --error --no-wrap --title="devmon error" \
-							  --text="udisks functions are not authorized through policykit,\nso devmon cannot automount drives.\nPlease install udevil or see devmon's consolekit installation instructions:\n\nhttp://igurublog.wordpress.com/downloads/script-devmon/#install\n\n(To silence this pop-up add --no-gui to devmon's command line.)" &> /dev/null ) &
+							( sleep 3 && WINDOWID="" $zenity --error --no-wrap --title="$msgtitle" \
+							  --text="$msg" &> /dev/null ) &
 						else
-							( sleep 3 && $notify_send --icon=dialog-error "devmon error" "udisks functions are not authorized through policykit,\nso devmon cannot automount drives.\nPlease install udevil or see devmon's consolekit installation instructions:\n\nhttp://igurublog.wordpress.com/downloads/script-devmon/#install\n\n(To silence this pop-up add --no-gui to devmon's command line.)" &> /dev/null ) &
+							( sleep 3 && $notify_send --icon=dialog-error "$msgtitle" "$msg" &> /dev/null ) &
 						fi
+						unset msg msgtitle
 					fi
 					echo "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@" 1>&2
 					echo "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@" 1>&2
@@ -724,18 +735,19 @@ mountdrive()   # $1=device $2=label  [$3=devtype or fstype]
 		sleep .5
 		echo "devmon: [info on mount] $dv"
 		if (( nogui != 1 )); then
+			msgtitle="devmon mount"
+			msg="The following device has been mounted:\n\n$(df -hT "$dv" | \
+				awk '$1 == "'$dv'" {print "Device:\\t"$1"\x0AType:\\t"$2"\nSize:\\t\\t"$3"\nUsed:\\t"$4"\n""Avail:\\t"$5"\nUse%:\\t"$6"\nMount:\\t"$7,$8,$9,$10}')\nLabel:\\t$lb"
 			if [ "$spacefm" != "" ]; then
-				$spacefm -g --title "devmon mount" --window-icon drive-removable-media --label \
-				"The following device has been mounted:\n\n$(df -hT "$dv" | grep "$dv" | \
-				awk '{print "Device:\\t"$1"\x0AType:\\t"$2"\nSize:\\t\\t"$3"\nUsed:\\t"$4"\n""Avail:\\t"$5"\nUse%:\\t"$6"\nMount:\\t"$7,$8,$9,$10}')\nLabel:\\t$lb" \
+				$spacefm -g --title "$msgtitle" --window-icon drive-removable-media --label \
+				"$msg" \
 				--button open spacefm "$point" --button ok &>/dev/null &
 			elif [ "$zenity" != "" ]; then
-				WINDOWID="" $zenity --info --text="The following device has been mounted:\n\n$(df -hT "$dv" \
-			   | grep "$dv" | awk '{print "Device:\\t"$1"\x0AType:\\t"$2"\nSize:\\t\\t"$3"\nUsed:\\t"$4"\n""Avail:\\t"$5"\nUse%:\\t"$6"\nMount:\\t"$7,$8,$9,$10}')\nLabel:\\t$lb" --title="devmon mount" &
+				WINDOWID="" $zenity --info --text="$msg" --title="$msgtitle" &
 			else
-				$notify_send --icon=media-removable "devmon mount" "The following device has been mounted:\n\n$(df -hT "$dv" \
-				 | grep "$dv" | awk '{print "Device:\\t"$1"\x0AType:\\t"$2"\nSize:\\t\\t"$3"\nUsed:\\t"$4"\n""Avail:\\t"$5"\nUse%:\\t"$6"\nMount:\\t"$7,$8,$9,$10}')\nLabel:\\t$lb" &
+				$notify_send --icon=media-removable "$msgtitle" "$msg" &
 			fi
+			unset msgtitle msg
 		fi
 		df -hT "$dv"
 	fi
@@ -955,17 +967,19 @@ if (( mountmode != 0 )); then
 						else
 							lb=" ($label)"
 						fi
+						msgtitle="devmon unmount optical"
 						msg="Unmount error on /dev/sr$x$lb:\n\n$uerrmsg"
 						if [ "$spacefm" != "" ]; then
-							spacefm -g --title "devmon unmount optical" \
+							spacefm -g --title "$msgtitle" \
 							           --window-icon error \
 							           --label "$msg" --button close &> /dev/null &
 						elif [ "$zenity" != "" ]; then
-							WINDOWID="" zenity --error --title="devmon unmount optical" \
+							WINDOWID="" zenity --error --title="$msgtitle" \
 						                   --text="$msg" &> /dev/null &
 						else
-							"$notify_send" --icon=dialog_error "devmon unmount optical" "$msg"
+							"$notify_send" --icon=dialog-error "$msgtitle" "$msg"
 						fi
+						unset msgtitle msg
 					fi	
 				fi
 			fi


### PR DESCRIPTION
Addresses #70. Only attempts to use `notify-send` if both `spacefm` and `zenity` are absent.

![eject](https://cloud.githubusercontent.com/assets/3425234/20645099/dcc43a72-b406-11e6-8cdc-c7ee310db6b7.png)

~~~NB, I have not been able to get the "info on mount" notification to execute. I'm using an `--exec-on-drive` option for that.~~~ `--info-on-mount` works like it's supposed to