### PR TITLE
remove nonempty option for exfat

### DIFF
--- a/etc/udevil.conf
+++ b/etc/udevil.conf
@@ -221,7 +221,7 @@ default_options_file      = nosuid, noexec, nodev, noatime, uid=$UID, gid=$GID, 
 default_options_iso9660   = nosuid, noexec, nodev, noatime, uid=$UID, gid=$GID, ro, utf8
 default_options_udf       = nosuid, noexec, nodev, noatime, uid=$UID, gid=$GID
 default_options_vfat      = nosuid, noexec, nodev, noatime, fmask=0133, dmask=0022, uid=$UID, gid=$GID, utf8
-default_options_exfat     = nosuid, noexec, nodev, noatime, umask=0077, uid=$UID, gid=$GID, iocharset=utf8, namecase=0, nonempty
+default_options_exfat     = nosuid, noexec, nodev, noatime, umask=0077, uid=$UID, gid=$GID, iocharset=utf8, namecase=0
 default_options_msdos     = nosuid, noexec, nodev, noatime, fmask=0133, dmask=0022, uid=$UID, gid=$GID
 default_options_umsdos    = nosuid, noexec, nodev, noatime, fmask=0133, dmask=0022, uid=$UID, gid=$GID
 default_options_ntfs      = nosuid, noexec, nodev, noatime, fmask=0133, uid=$UID, gid=$GID, utf8


### PR DESCRIPTION
remove nonempty default option for exfat which is not supported by the kernel exfat driver --> see #89 