### PR TITLE
Include missing headers

### DIFF
--- a/src/device-info.h
+++ b/src/device-info.h
@@ -12,7 +12,6 @@
 
 // POSIX
 #include <sys/stat.h>
-#include <unistd.h>
 
 // udev
 #include <libudev.h>

--- a/src/device-info.h
+++ b/src/device-info.h
@@ -10,6 +10,10 @@
 // glib
 #include <glib.h>
 
+// POSIX
+#include <sys/stat.h>
+#include <unistd.h>
+
 // udev
 #include <libudev.h>
 #include <fcntl.h>


### PR DESCRIPTION
Added `<sys/stat.h>` to fix the mismatched pointer types and implicitly declare `stat()` and `S_ISBLK()` to fix the errors below that I encountered while installing.

```
udevil.c:4783:21: error: passing argument 2 of ‘signal’ from incompatible pointer type [-Wincompatible-pointer-types]
udevil.c:4784:21: error: passing argument 2 of ‘signal’ from incompatible pointer type [-Wincompatible-pointer-types]
udevil.c:4923:22: error: passing argument 2 of ‘signal’ from incompatible pointer type [-Wincompatible-pointer-types]
udevil.c:4924:22: error: passing argument 2 of ‘signal’ from incompatible pointer type [-Wincompatible-pointer-types]
udevil.c:4925:22: error: passing argument 2 of ‘signal’ from incompatible pointer type [-Wincompatible-pointer-types]
```



```
error: implicit declaration of function ‘stat’; did you mean ‘strcat’? [-Wimplicit-function-declaration]
  943 |                                 stat( mount_source, &statbuf ) == 0 &&
      |                                 ^~~~
      |                                 strcat
device-info.c:944:33: error: implicit declaration of function ‘S_ISBLK’; did you mean ‘S_IFBLK’? [-Wimplicit-function-declaration]
  944 |                                 S_ISBLK( statbuf.st_mode ) )
      |                                 ^~~~~~~
      |                                 S_IFBLK
```