### PR TITLE
fix discard const qualifier

### DIFF
--- a/src/udevil.c
+++ b/src/udevil.c
@@ -681,7 +681,7 @@ char *replace_string( const char* orig, const char* str, const char* replace,
     const char* cur;
     char* result = NULL;
     char* old_result;
-    char* s;
+    const char* s;
 
     if ( !orig || !( s = strstr( orig, str ) ) )
         return g_strdup( orig );  // str not in orig
@@ -1314,13 +1314,13 @@ static char* validate_options( const char* name, const char* type,
                                                             const char* options )
 {
     char* fulllist = NULL;
-    char* list;
     char* str;
-    char* comma;
     char* element;
     char* oelement;
     char* selement;
     char* opt;
+    const char* comma;
+    const char* list;
     const char* opts;
     gboolean found;
     char* ret = NULL;


### PR DESCRIPTION
Since glibc-2.43 and ISO C23, the functions bsearch, memchr, strchr, strpbrk, strrchr, strstr, wcschr, wcspbrk, wcsrchr, wcsstr and wmemchr that return pointers into their input arrays now have definitions as macros that return a pointer to a const-qualified type when the in put argument is a pointer to a const-qualified type.

https://lists.gnu.org/archive/html/info-gnu/2026-01/msg00005.html

Fixes:
    ../../src/udevil.c: In function 'replace_string':
    ../../src/udevil.c:683:24: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
      683 |     if ( !orig || !( s = strstr( orig, str ) ) )
          |                        ^
    ../../src/udevil.c:711:11: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
      711 |         s = strstr( cur, str );
          |           ^
    ../../src/udevil.c: In function 'validate_options':
    ../../src/udevil.c:1332:21: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
     1332 |         if ( (comma = strchr( opts, ',' )) )
          |                     ^