### PR TITLE
fix: update command_interrupt and command_monitor_finalize functions …

### DIFF
--- a/src/udevil.c
+++ b/src/udevil.c
@@ -4795,7 +4795,7 @@ static int command_info( CommandData* data )
     return ret;
 }
 
-void command_monitor_finalize()
+void command_monitor_finalize(int signum)
 {
     //if (signal == SIGINT || signal == SIGTERM)
     //printf( "\nudevil: SIGINT || SIGTERM\n");
@@ -4913,7 +4913,7 @@ finish_:
     return 1;
 }
 
-void command_interrupt()
+void command_interrupt(int signum)
 {
     if ( udev )
     {


### PR DESCRIPTION
…to pass sigint

This fixes compile error with gcc-15

/usr/include/signal.h:88:57: note: expected '__sighandler_t' {aka 'void (*)(int)'} but argument is of type 'void (*)(void)'
   88 | extern __sighandler_t signal (int __sig, __sighandler_t __handler)
      |                                          ~~~~~~~~~~~~~~~^~~~~~~~~
../../src/udevil.c:5033:21: error: passing argument 2 of 'signal' from incompatible pointer type [-Wincompatible-pointer-types]
 5033 |     signal(SIGINT,  command_monitor_finalize );
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~
      |                     |
      |                     void (*)(void)
/usr/include/signal.h:88:57: note: expected '__sighandler_t' {aka 'void (*)(int)'} but argument is of type 'void (*)(void)'
   88 | extern __sighandler_t signal (int __sig, __sighandler_t __handler)
      |                                          ~~~~~~~~~~~~~~~^~~~~~~~~
../../src/udevil.c: In function 'main':
../../src/udevil.c:5176:22: error: passing argument 2 of 'signal' from incompatible pointer type [-Wincompatible-pointer-types]
 5176 |     signal( SIGTERM, command_interrupt );
      |                      ^~~~~~~~~~~~~~~~~
      |                      |
      |                      void (*)(void)