### PR TITLE
Code updates to fix compiler warnings

### DIFF
--- a/src/device-info.c
+++ b/src/device-info.c
@@ -259,7 +259,6 @@ void info_drive_connection( device_t *device )
 {
   char *s;
   char *p;
-  char *q;
   char *model;
   char *vendor;
   char *subsystem;

--- a/src/device-info.c
+++ b/src/device-info.c
@@ -221,7 +221,7 @@ gboolean info_is_system_internal( device_t *device )
 {
     const char *value;
 
-    if ( value = udev_device_get_property_value( device->udevice, "UDISKS_SYSTEM_INTERNAL" ) )
+    if ( (value = udev_device_get_property_value( device->udevice, "UDISKS_SYSTEM_INTERNAL" )) )
         return atoi( value ) != 0;
 
     /* A Linux MD device is system internal if, and only if
@@ -546,25 +546,25 @@ void info_drive_properties ( device_t *device )
     device->device_is_drive = sysfs_file_exists( device->native_path, "range" );
 
     // vendor
-    if ( value = udev_device_get_property_value( device->udevice, "ID_VENDOR_ENC" ) )
+    if ( (value = udev_device_get_property_value( device->udevice, "ID_VENDOR_ENC" )) )
     {
         decoded_string = decode_udev_encoded_string ( value );
         g_strstrip (decoded_string);
         device->drive_vendor = decoded_string;
     }
-    else if ( value = udev_device_get_property_value( device->udevice, "ID_VENDOR" ) )
+    else if ( (value = udev_device_get_property_value( device->udevice, "ID_VENDOR" )) )
     {
         device->drive_vendor = g_strdup( value );
     }
 
     // model
-    if ( value = udev_device_get_property_value( device->udevice, "ID_MODEL_ENC" ) )
+    if ( (value = udev_device_get_property_value( device->udevice, "ID_MODEL_ENC" )) )
     {
         decoded_string = decode_udev_encoded_string ( value );
         g_strstrip (decoded_string);
         device->drive_model = decoded_string;
     }
-    else if ( value = udev_device_get_property_value( device->udevice, "ID_MODEL" ) )
+    else if ( (value = udev_device_get_property_value( device->udevice, "ID_MODEL" )) )
     {
         device->drive_model = g_strdup( value );
     }
@@ -574,7 +574,7 @@ void info_drive_properties ( device_t *device )
                                                     device->udevice, "ID_REVISION" ) );
 
     // serial
-    if ( value = udev_device_get_property_value( device->udevice, "ID_SCSI_SERIAL" ) )
+    if ( (value = udev_device_get_property_value( device->udevice, "ID_SCSI_SERIAL" )) )
     {
         /* scsi_id sometimes use the WWN as the serial - annoying - see
         * http://git.kernel.org/?p=linux/hotplug/udev.git;a=commit;h=4e9fdfccbdd16f0cfdb5c8fa8484a8ba0f2e69d3
@@ -582,17 +582,17 @@ void info_drive_properties ( device_t *device )
         */
         device->drive_serial = g_strdup( value );
     }
-    else if ( value = udev_device_get_property_value( device->udevice, "ID_SERIAL_SHORT" ) )
+    else if ( (value = udev_device_get_property_value( device->udevice, "ID_SERIAL_SHORT" )) )
     {
         device->drive_serial = g_strdup( value );
     }
 
     // wwn
-    if ( value = udev_device_get_property_value( device->udevice, "ID_WWN_WITH_EXTENSION" ) )
+    if ( (value = udev_device_get_property_value( device->udevice, "ID_WWN_WITH_EXTENSION" )) )
     {
         device->drive_wwn = g_strdup( value + 2 );
     }
-    else if ( value = udev_device_get_property_value( device->udevice, "ID_WWN" ) )
+    else if ( (value = udev_device_get_property_value( device->udevice, "ID_WWN" )) )
     {
         device->drive_wwn = g_strdup( value + 2 );
     }
@@ -604,7 +604,7 @@ void info_drive_properties ( device_t *device )
     info_drive_connection( device );
 
     // is_ejectable
-    if ( value = udev_device_get_property_value( device->udevice, "ID_DRIVE_EJECTABLE" ) )
+    if ( (value = udev_device_get_property_value( device->udevice, "ID_DRIVE_EJECTABLE" )) )
     {
         drive_is_ejectable = atoi( value ) != 0;
     }
@@ -684,7 +684,7 @@ void info_drive_properties ( device_t *device )
     {
       drive_can_detach = TRUE;
     }
-    if ( value = udev_device_get_property_value( device->udevice, "ID_DRIVE_DETACHABLE" ) )
+    if ( (value = udev_device_get_property_value( device->udevice, "ID_DRIVE_DETACHABLE" )) )
     {
         drive_can_detach = atoi( value ) != 0;
     }
@@ -729,7 +729,7 @@ void info_device_properties( device_t *device )
     gint partition_type = 0;
 
     partition_scheme = udev_device_get_property_value( device->udevice, "UDISKS_PARTITION_SCHEME");
-    if ( value = udev_device_get_property_value( device->udevice, "UDISKS_PARTITION_TYPE") )
+    if ( (value = udev_device_get_property_value( device->udevice, "UDISKS_PARTITION_TYPE")) )
         partition_type = atoi( value );
     if (g_strcmp0 (partition_scheme, "mbr") == 0 && (partition_type == 0x05 ||
                                                    partition_type == 0x0f ||
@@ -747,13 +747,13 @@ void info_device_properties( device_t *device )
         device->id_uuid = g_strdup( udev_device_get_property_value( device->udevice,
                                                         "ID_FS_UUID" ) );
 
-        if ( value = udev_device_get_property_value( device->udevice, "ID_FS_LABEL_ENC" ) )
+        if ( (value = udev_device_get_property_value( device->udevice, "ID_FS_LABEL_ENC" )) )
         {
             decoded_string = decode_udev_encoded_string ( value );
             g_strstrip (decoded_string);
             device->id_label = decoded_string;
         }
-        else if ( value = udev_device_get_property_value( device->udevice, "ID_FS_LABEL" ) )
+        else if ( (value = udev_device_get_property_value( device->udevice, "ID_FS_LABEL" )) )
         {
             device->id_label = g_strdup( value );
         }
@@ -774,12 +774,12 @@ void info_device_properties( device_t *device )
     else if ( device->device_is_removable )
     {
         gboolean is_cd, is_floppy;
-        if ( value = udev_device_get_property_value( device->udevice, "ID_CDROM" ) )
+        if ( (value = udev_device_get_property_value( device->udevice, "ID_CDROM" )) )
             is_cd = atoi( value ) != 0;
         else
             is_cd = FALSE;
 
-        if ( value = udev_device_get_property_value( device->udevice, "ID_DRIVE_FLOPPY" ) )
+        if ( (value = udev_device_get_property_value( device->udevice, "ID_DRIVE_FLOPPY" )) )
             is_floppy = atoi( value ) != 0;
         else
             is_floppy = FALSE;
@@ -796,10 +796,10 @@ void info_device_properties( device_t *device )
                 close( fd );
             }
         }
-        else if ( value = udev_device_get_property_value( device->udevice, "ID_CDROM_MEDIA" ) )
+        else if ( (value = udev_device_get_property_value( device->udevice, "ID_CDROM_MEDIA" )) )
             media_available = ( atoi( value ) == 1 );
     }
-    else if ( value = udev_device_get_property_value( device->udevice, "ID_CDROM_MEDIA" ) )
+    else if ( (value = udev_device_get_property_value( device->udevice, "ID_CDROM_MEDIA" )) )
         media_available = ( atoi( value ) == 1 );
     else
         media_available = TRUE;
@@ -975,7 +975,7 @@ gchar* info_mount_points( device_t *device, GList* devmounts )
         mounts = g_list_sort( mounts, (GCompareFunc) g_strcmp0 );
         points = g_strdup( (gchar*)mounts->data );
         l = mounts;
-        while ( l = l->next )
+        while ( (l = l->next) )
         {
             old_points = points;
             points = g_strdup_printf( "%s, %s", old_points, (gchar*)l->data );

--- a/src/udevil.c
+++ b/src/udevil.c
@@ -247,7 +247,7 @@ void parse_mounts( gboolean report )
         devmount->mounts = g_list_sort( devmount->mounts, (GCompareFunc) g_strcmp0 );
         m = devmount->mounts;
         points = g_strdup( (gchar*)m->data );
-        while ( m = m->next )
+        while ( (m = m->next) )
         {
             old_points = points;
             points = g_strdup_printf( "%s, %s", old_points, (gchar*)m->data );
@@ -437,7 +437,7 @@ if ( !( cond & G_IO_NVAL ) )
     const char *action;
     const char *acted = NULL;
     char* devnode;
-    if ( udevice = udev_monitor_receive_device( umonitor ) )
+    if ( (udevice = udev_monitor_receive_device( umonitor )) )
     {
         action = udev_device_get_action( udevice );
         devnode = g_strdup( udev_device_get_devnode( udevice ) );
@@ -975,7 +975,7 @@ static void lock_log( gboolean lock )
             i++;
         }
         // create lock file
-        if ( file = fopen( log_lock_file, "w" ) )
+        if ( (file = fopen( log_lock_file, "w" )) )
             fclose( file );
     }
     else
@@ -1056,7 +1056,7 @@ static void expire_log( guint days )
             return;
         }
         unlink( str );
-        if ( file = fopen( str, "w" ) )
+        if ( (file = fopen( str, "w" )) )
             fclose( file );
         g_free( str );
     }
@@ -1136,7 +1136,7 @@ static void dump_log()
 
     // clean expired log entries
     const char* daystr;
-    if ( daystr = read_config( "log_keep_days", NULL ) )
+    if ( (daystr = read_config( "log_keep_days", NULL )) )
     {
         guint days = atoi( daystr );
         if ( days > 0 )
@@ -1190,7 +1190,7 @@ static gboolean validate_in_list( const char* name, const char* type, const char
 //printf("list[%s_%s] = {%s}\n", name, type, list );
     while ( list && list[0] )
     {
-        if ( comma = strchr( list, ',' ) )
+        if ( (comma = strchr( list, ',' )) )
         {
             element = g_strndup( list, comma - list );
             list = comma + 1;
@@ -1267,7 +1267,7 @@ static gboolean validate_in_groups( const char* name, const char* type,
 
     while ( list && list[0] )
     {
-        if ( comma = strchr( list, ',' ) )
+        if ( (comma = strchr( list, ',' )) )
         {
             element = g_strndup( list, comma - list );
             list = comma + 1;
@@ -1336,7 +1336,7 @@ static char* validate_options( const char* name, const char* type,
     while ( opts && opts[0] )
     {
         // get an option
-        if ( comma = strchr( opts, ',' ) )
+        if ( (comma = strchr( opts, ',' )) )
         {
             oelement = g_strndup( opts, comma - opts );
             opts = comma + 1;
@@ -1355,7 +1355,7 @@ static char* validate_options( const char* name, const char* type,
         found = FALSE;
         while ( list && list[0] )
         {
-            if ( comma = strchr( list, ',' ) )
+            if ( (comma = strchr( list, ',' )) )
             {
                 element = g_strndup( list, comma - list );
                 list = comma + 1;
@@ -1668,7 +1668,7 @@ static char* get_loop_from_file( const char* path )
 
         if ( !exit_status && stdout )
         {
-            if ( str = strchr( stdout, ':' ) )
+            if ( (str = strchr( stdout, ':' )) )
             {
                 str[0] = '\0';
                 if ( g_str_has_prefix( stdout, "/dev/loop" ) )
@@ -1937,7 +1937,7 @@ static gboolean path_is_mounted_block( const char* path, char** device_file )
     g_strfreev( lines );
     if ( ret && device_file )
     {
-        if ( udev = udev_new() )
+        if ( (udev = udev_new()) )
         {
             struct udev_device *udevice;
             dev_t dev;
@@ -2409,7 +2409,7 @@ static char* get_default_mount_dir( const char* type )
     char* auto_media = g_build_filename( AUTO_MEDIA_DIR, g_get_user_name(), NULL );
     while ( list && list[0] )
     {
-        if ( comma = strchr( list, ',' ) )
+        if ( (comma = strchr( list, ',' )) )
         {
             element = g_strndup( list, comma - list );
             list = comma + 1;
@@ -2537,7 +2537,7 @@ static int parse_network_url( const char* url, const char* fstype,
         else
         {
             // detect curlftpfs or ftpfs
-            if ( str = g_find_program_in_path( "curlftpfs" ) )
+            if ( (str = g_find_program_in_path( "curlftpfs" )) )
                 nm->fstype = g_strdup( "curlftpfs" );
             else
                 nm->fstype = g_strdup( "ftpfs" );
@@ -2638,15 +2638,15 @@ static int parse_network_url( const char* url, const char* fstype,
     char* trim_url = g_strdup( xurl );
 
     // user:pass
-    if ( str = strchr( xurl, '@' ) )
+    if ( (str = strchr( xurl, '@' )) )
     {
-        if ( str2 = strchr( str + 1, '@' ) )
+        if ( (str2 = strchr( str + 1, '@' )) )
         {
             // there is a second @ - assume username contains email address
             str = str2;
         }
         str[0] = '\0';
-        if ( str2 = strchr( xurl, ':' ) )
+        if ( (str2 = strchr( xurl, ':' )) )
         {
             str2[0] = '\0';
             if ( str2[1] != '\0' )
@@ -2658,7 +2658,7 @@ static int parse_network_url( const char* url, const char* fstype,
     }
 
     // path
-    if ( str = strchr( xurl, '/' ) )
+    if ( (str = strchr( xurl, '/' )) )
     {
         nm->path = g_strdup( str );
         str[0] = '\0';
@@ -2668,7 +2668,7 @@ static int parse_network_url( const char* url, const char* fstype,
     if ( xurl[0] == '[' )
     {
         // ipv6 literal
-        if ( str = strchr( xurl, ']' ) )
+        if ( (str = strchr( xurl, ']' )) )
         {
             str[0] = '\0';
             if ( xurl[1] != '\0' )
@@ -2679,7 +2679,7 @@ static int parse_network_url( const char* url, const char* fstype,
     }
     else if ( xurl[0] != '\0' )
     {
-        if ( str = strchr( xurl, ':' ) )
+        if ( (str = strchr( xurl, ':' )) )
         {
             str[0] = '\0';
             if ( str[1] != '\0' )
@@ -2829,7 +2829,7 @@ _get_type:
     }
 
     // determine mount type
-    if ( i = parse_network_url( data->device_file, data->fstype, &netmount ) )
+    if ( (i = parse_network_url( data->device_file, data->fstype, &netmount )) )
     {
         if ( i == 2 )
         {
@@ -3016,7 +3016,7 @@ _get_type:
                             // cifs ipv6 mtab format: //::1/share
                             // add literal brackets:  //[::1]/share
                             str = g_strdup( data->device_file + 2 );
-                            if ( str2 = strchr( str, '/' ) )
+                            if ( (str2 = strchr( str, '/' )) )
                                 str2[0] = '\0';
                             g_free( data->device_file );
                             data->device_file = g_strdup_printf( "//[%s]%s%s",
@@ -3039,7 +3039,7 @@ _get_type:
         else
         {
             // unmounting a file
-            if ( str = get_loop_from_file( data->device_file ) )
+            if ( (str = get_loop_from_file( data->device_file )) )
             {
                 // unmounting a file attached to loop
                 if ( !get_realpath( &str ) )
@@ -3279,7 +3279,7 @@ _get_type:
             char* list = device->mount_points;
             while ( list && list[0] )
             {
-                if ( comma = strchr( list, ',' ) )
+                if ( (comma = strchr( list, ',' )) )
                 {
                     element = g_strndup( list, comma - list );
                     list = comma + 1;
@@ -3728,7 +3728,7 @@ _get_type:
         {
             if ( netmount->user )
             {
-                if ( str = strchr( netmount->user, '/' ) )
+                if ( (str = strchr( netmount->user, '/' )) )
                 {
                     // domain included   DOMAIN/USER@HOST
                     str[0] = '\0';
@@ -3810,7 +3810,7 @@ _get_type:
         ret = 1;
         goto _finish;
     }
-    if ( str = validate_options( "allowed_options", fstype, options ) )
+    if ( (str = validate_options( "allowed_options", fstype, options )) )
     {
         wlog( _("udevil: denied 90: option '%s' is not an allowed option\n"), str, 2 );
         g_free( str );
@@ -4567,7 +4567,7 @@ static int command_remove( CommandData* data )
     
     // now extract the part we want, up to the grand-parent of the host
     // e.g: /sys/devices/pci0000:00/0000:00:06.0/usb1/1-2
-    while ( c = strrchr( host_path, '/' ) )
+    while ( (c = strrchr( host_path, '/' )) )
     {
         // end the string there, to move back
         *c = 0;
@@ -4685,7 +4685,7 @@ static int command_clean()
     restore_privileges();
     while ( list && list[0] )
     {
-        if ( comma = strchr( list, ',' ) )
+        if ( (comma = strchr( list, ',' )) )
         {
             element = g_strndup( list, comma - list );
             list = comma + 1;
@@ -4705,7 +4705,7 @@ static int command_clean()
             dir = g_dir_open( selement, 0, NULL );
             if ( dir )
             {
-                while ( name = g_dir_read_name( dir ) )
+                while ( (name = g_dir_read_name( dir )) )
                 {
                     path = g_build_filename( selement, name, ".udevil-mount-point", NULL );
                     if ( stat( path, &statbuf ) == 0 && S_ISREG( statbuf.st_mode )

--- a/src/udevil.c
+++ b/src/udevil.c
@@ -435,7 +435,6 @@ if ( !( cond & G_IO_NVAL ) )
 
     struct udev_device *udevice;
     const char *action;
-    const char *acted = NULL;
     char* devnode;
     if ( (udevice = udev_monitor_receive_device( umonitor )) )
     {
@@ -637,7 +636,6 @@ char* get_known_filesystems()
     // get additional types from files
     static const char *type_files[] = { "/proc/filesystems", "/etc/filesystems", NULL };
     gchar *filesystems;
-    GError *error;
     gchar **lines;
     guint n;
     char* str;
@@ -646,7 +644,6 @@ char* get_known_filesystems()
     {
         filesystems = NULL;
         lines = NULL;
-        error = NULL;
         if ( g_file_get_contents( type_files[i], &filesystems, NULL, NULL ) )
         {
             lines = g_strsplit (filesystems, "\n", -1);
@@ -781,7 +778,6 @@ static char* parse_config( int* config_warning )
     FILE* file;
     char line[ 2048 ];
     char* conf_path;
-    char* sline;
     char* equal;
     char* var;
     char* value;
@@ -953,7 +949,6 @@ static void wlog( const char* msg, const char* sub1, int volume )
 static void lock_log( gboolean lock )
 {
     FILE* file;
-    char* name;
     struct stat statbuf;
 
     const char* rlock = "/run/lock";
@@ -1252,7 +1247,6 @@ static gboolean validate_in_groups( const char* name, const char* type,
                                                             const char* username )
 {
     char* list = NULL;
-    char* str;
     char* comma;
     char* element;
     char* selement;
@@ -1315,7 +1309,6 @@ static char* validate_options( const char* name, const char* type,
 {
     char* fulllist = NULL;
     char* list;
-    char* str;
     char* comma;
     char* element;
     char* oelement;
@@ -1502,7 +1495,6 @@ int user_on_tty()
 static void detach_loop( const char* loopdev )
 {
     char* stdout = NULL;
-    char* str;
     int status = 0;
     int exit_status = 1;
     gchar *argv[4] = { NULL };
@@ -1600,7 +1592,6 @@ static char* attach_fd_to_loop( const char* device_file, int fd )
     }
     
     char* stdout = NULL;
-    char* str;
     int status = 0;
     int exit_status = 1;
     gchar *argv[4] = { NULL };
@@ -1750,7 +1741,6 @@ static gboolean device_is_mounted_mtab( const char* device_file, char** mount_po
     GError *error;
     guint n;
     gboolean ret = FALSE;
-    char* str;
     char* file;
     gchar encoded_file[PATH_MAX];
     gchar encoded_point[PATH_MAX];
@@ -1813,8 +1803,6 @@ static gboolean path_is_mounted_mtab( const char* path, char** device_file )
     GError *error;
     guint n;
     gboolean ret = FALSE;
-    char* str;
-    char* file;
     char* point;
     gchar encoded_file[PATH_MAX];
     gchar encoded_point[PATH_MAX];
@@ -4329,7 +4317,6 @@ static int command_remove( CommandData* data )
     const char* device_file = data->device_file;
     char* str;
     char* str2;
-    int ret = 0;
     
     // got root?
     if ( orig_euid != 0 )
@@ -4562,7 +4549,6 @@ static int command_remove( CommandData* data )
     
     // stop device - contains code from pmount-jjk
     char *c;
-    FILE *f;
     path = NULL;
     
     // now extract the part we want, up to the grand-parent of the host


### PR DESCRIPTION
2 small code updates to silence compiler warnings.
- fix: clean up unused variables to silence compiler warnings
- fix: compiler warning suggest parentheses around assignment used as truth value

only compile warning remaining is:
```
../../src/udevil.c: In function 'detach_loop':
../../src/udevil.c:1499:9: warning: variable 'exit_status' set but not used [-Wunused-but-set-variable]
 1499 |     int exit_status = 1;
      |         ^~~~~~~~~~~
```